### PR TITLE
Allow to select search api without change config

### DIFF
--- a/src/components/autocomplete.vue
+++ b/src/components/autocomplete.vue
@@ -223,19 +223,21 @@ export default {
         // avoid to fire request if nothing was input
         return;
       }
-      let url;
+        let url;
       // clear last results
       this.data = [];
       // start loader animation
       this.isFetching = true;
-      this.api = this.getParam('search');
+      // get api name to use from input. ex : ban/paris or nominatim/paris.
+      let text = this.name.split('/');
+      let request = text.length > 1 ? text[1] : text[0];
+      this.api = text.length > 1 ? text[0] : this.getParam('search');
       
       if(this.api === "nominatim") {
-        url =  this.apiNominatim + this.name;
+        url =  this.apiNominatim + request;
       } else {
-        url = this.apiBan + this.name;
+        url = this.apiBan + request;
       }
-      
       axios
         .get(url)
         // promise


### PR DESCRIPTION
Use `ban/paris` or `nominatim/paris` to select api from input directly.

2 way to use api :

* From config
Just write city or adress in autocomplete input bar.

* From autocomplete input bar directly with `ban/paris` or `nominatim/paris` 
